### PR TITLE
Remove qrm_readmat and qrm_readmat! functions

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -52,11 +52,6 @@ qrm_residual_orth
 ```
 
 ```@docs
-qrm_readmat
-qrm_readmat!
-```
-
-```@docs
 qrm_spfct_seti
 qrm_spfct_geti
 qrm_spfct_getii

--- a/src/qr_mumps.jl
+++ b/src/qr_mumps.jl
@@ -25,7 +25,6 @@ export qrm_spmat, qrm_spfct,
     qrm_init, qrm_finalize,
     qrm_spmat_init!, qrm_spmat_init, qrm_spmat_destroy!,
     qrm_spfct_init!, qrm_spfct_init, qrm_spfct_destroy!,
-    qrm_readmat!, qrm_readmat,
     qrm_analyse!, qrm_analyse,
     qrm_factorize!,
     qrm_solve!, qrm_solve,
@@ -346,12 +345,6 @@ Computes the quantity ``\frac{\|A^T r\|_2}{\|r\|_2}`` which can be used to evalu
 * r: the residual(s).
 """
 function qrm_residual_orth end
-
-"TO DO!"
-function qrm_readmat! end
-
-"TO DO!"
-function qrm_readmat end
 
 "TO DO!"
 function qrm_spfct_seti end

--- a/src/wrapper/qr_mumps_api.jl
+++ b/src/wrapper/qr_mumps_api.jl
@@ -106,25 +106,6 @@ for (fname, lname, elty, subty) in (("sqrm_spfct_destroy_c", libsqrm, Float32   
     end
 end
 
-for (fname, lname, elty, subty) in (("sqrm_readmat_c", libsqrm, Float32   , Float32),
-                                    ("dqrm_readmat_c", libdqrm, Float64   , Float64),
-                                    ("cqrm_readmat_c", libcqrm, ComplexF32, Float32),
-                                    ("zqrm_readmat_c", libzqrm, ComplexF64, Float64))
-    @eval begin
-        function qrm_readmat!(matfile :: String, spmat :: qrm_spmat{$elty})
-            ptr_spmat = Ptr{qrm_spmat{$elty}}(pointer_from_objref(spmat))
-            ccall(($fname, $lname), Cvoid, (String, Ptr{qrm_spmat{$elty}}), matfile, ptr_spmat)
-        end
-
-        function qrm_readmat(::Type{$elty}, matfile :: String)
-            spmat = qrm_spmat{$elty}()
-            ptr_spmat = Ptr{qrm_spmat{$elty}}(pointer_from_objref(spmat))
-            ccall(($fname, $lname), Cvoid, (String, Ptr{qrm_spmat{$elty}}), matfile, ptr_spmat)
-            return spmat
-        end
-    end
-end
-
 for (fname, lname, elty, subty) in (("sqrm_analyse_c", libsqrm, Float32   , Float32),
                                     ("dqrm_analyse_c", libdqrm, Float64   , Float64),
                                     ("cqrm_analyse_c", libcqrm, ComplexF32, Float32),


### PR DESCRIPTION
`qrm_readmat` and `qrm_readmat!` are not relevant for the interface.