### PR TITLE
Fix qrm_spmat_nrm, qrm_vecnrm, qrm_residual_norm and qrm_residual_orth functions

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -46,8 +46,11 @@ qrm_min_norm!
 ```@docs
 qrm_spmat_mv!
 qrm_spmat_nrm
+qrm_vecnrm!
 qrm_vecnrm
+qrm_residual_norm!
 qrm_residual_norm
+qrm_residual_orth!
 qrm_residual_orth
 ```
 

--- a/src/qr_mumps.jl
+++ b/src/qr_mumps.jl
@@ -198,33 +198,33 @@ This subroutine performs a matrix-vector product of the type y = αAx + βy or y
 function qrm_spmat_mv! end
 
 @doc raw"""
-    qrm_spmat_nrm(spmat, ntype, nrm)
+    qrm_spmat_nrm(spmat, nrm; ntype='f')
 
 This routine computes the one-norm ``\|A\|_1``, the infinity-norm ``\|x\|_{\infty}`` or the two-norm ``\|x\|_2`` of a matrix.
 
 #### Input Arguments :
 
 * `spmat`: the input matrix.
-* `ntype`: the type of norm to be computed. It can be either `'i'`, `'1'` or `'f'` for the infinity, one and Frobenius norms, respectively.
 * `nrm`: the computed norm.
+* `ntype`: the type of norm to be computed. It can be either `'i'`, `'1'` or `'f'` for the infinity, one and Frobenius norms, respectively.
 """
 function qrm_spmat_nrm end
 
 @doc raw"""
-    qrm_vecnrm!(x, ntype, nrm)
+    qrm_vecnrm!(x, nrm; ntype='2')
 
 This routine computes the one-norm ``\|x\|_1``, the infinity-norm ``\|x\|_{\infty}`` or the two-norm ``\|x\|_2`` of a vector.
 
 #### Input Arguments :
 
 * `x`: the x vector(s).
-* `ntype`: the type of norm to be computed. It can be either `'i'`, `'1'` or `'2'` for the infinity, one and two norms, respectively.
 * `nrm`: the computed norm(s). If x is a matrix this argument has to be a vector and each of its elements will contain the norm of the corresponding column of x.
+* `ntype`: the type of norm to be computed. It can be either `'i'`, `'1'` or `'2'` for the infinity, one and two norms, respectively.
 """
 function qrm_vecnrm! end
 
 @doc raw"""
-    nrm = qrm_vecnrm(x, ntype)
+    nrm = qrm_vecnrm(x; ntype='2')
 """
 function qrm_vecnrm end
 

--- a/src/qr_mumps.jl
+++ b/src/qr_mumps.jl
@@ -27,12 +27,14 @@ export qrm_spmat, qrm_spfct,
     qrm_factorize!,
     qrm_solve!, qrm_solve,
     qrm_apply!, qrm_apply,
-    qrm_spmat_mv!, qrm_spmat_nrm, qrm_vecnrm,
+    qrm_spmat_mv!, qrm_spmat_nrm,
+    qrm_vecnrm!, qrm_vecnrm,
     qrm_spbackslash!, qrm_spbackslash, \,
     qrm_spposv!, qrm_spposv,
     qrm_least_squares!, qrm_least_squares,
     qrm_min_norm!, qrm_min_norm,
-    qrm_residual_norm, qrm_residual_orth,
+    qrm_residual_norm!, qrm_residual_norm,
+    qrm_residual_orth!, qrm_residual_orth,
     qrm_set, qrm_get
 
 @doc raw"""
@@ -203,21 +205,26 @@ This routine computes the one-norm ``\|A\|_1``, the infinity-norm ``\|x\|_{\inft
 #### Input Arguments :
 
 * `spmat`: the input matrix.
-* `ntype`: the type of norm to be computed. It can be either 'i', '1' or 'f' for the infinity, one and Frobenius norms, respectively.
+* `ntype`: the type of norm to be computed. It can be either `'i'`, `'1'` or `'f'` for the infinity, one and Frobenius norms, respectively.
 * `nrm`: the computed norm.
 """
 function qrm_spmat_nrm end
 
 @doc raw"""
-    qrm_vecnrm(x, ntype, nrm)
+    qrm_vecnrm!(x, ntype, nrm)
 
 This routine computes the one-norm ``\|x\|_1``, the infinity-norm ``\|x\|_{\infty}`` or the two-norm ``\|x\|_2`` of a vector.
 
 #### Input Arguments :
 
 * `x`: the x vector(s).
-* `ntype`: the type of norm to be computed. It can be either 'i', '1' or '2' for the infinity, one and two norms, respectively.
+* `ntype`: the type of norm to be computed. It can be either `'i'`, `'1'` or `'2'` for the infinity, one and two norms, respectively.
 * `nrm`: the computed norm(s). If x is a matrix this argument has to be a vector and each of its elements will contain the norm of the corresponding column of x.
+"""
+function qrm_vecnrm! end
+
+@doc raw"""
+    nrm = qrm_vecnrm(x, ntype)
 """
 function qrm_vecnrm end
 
@@ -319,7 +326,7 @@ function qrm_min_norm! end
 function qrm_min_norm end
 
 @doc raw"""
-    qrm_residual_norm(spmat, b, x)
+    qrm_residual_norm!(spmat, b, x, nrm)
 
 This function computes the scaled norm of the residual ``\frac{\|b - Ax\|_{\infty}}{\|b\|_{\infty} + \|x\|_{\infty} \|A\|_{\infty}}``, i.e., the normwise backward error.
 
@@ -328,11 +335,17 @@ This function computes the scaled norm of the residual ``\frac{\|b - Ax\|_{\inft
 * `spmat`: the input matrix.
 * `b`: the right-hand side(s).
 * `x`: the solution vector(s).
+* `nrm`: the computed norm(s).
+"""
+function qrm_residual_norm! end
+
+@doc raw"""
+    nrm = qrm_residual_norm(spmat, b, x)
 """
 function qrm_residual_norm end
 
 @doc raw"""
-    qrm_residual_orth(spmat, r)
+    qrm_residual_orth!(spmat, r, nrm)
 
 Computes the quantity ``\frac{\|A^T r\|_2}{\|r\|_2}`` which can be used to evaluate the quality of the solution of a least squares problem.
 
@@ -340,6 +353,12 @@ Computes the quantity ``\frac{\|A^T r\|_2}{\|r\|_2}`` which can be used to evalu
 
 * `spmat`: the input matrix.
 * `r`: the residual(s).
+* `nrm`: the computed norm(s).
+"""
+function qrm_residual_orth! end
+
+@doc raw"""
+    nrm = qrm_residual_orth(spmat, r)
 """
 function qrm_residual_orth end
 

--- a/src/wrapper/qr_mumps_api.jl
+++ b/src/wrapper/qr_mumps_api.jl
@@ -313,7 +313,7 @@ for (fname, lname, elty, subty) in (("sqrm_spmat_nrm_c", libsqrm, Float32   , Fl
                                     ("cqrm_spmat_nrm_c", libcqrm, ComplexF32, Float32),
                                     ("zqrm_spmat_nrm_c", libzqrm, ComplexF64, Float64))
     @eval begin
-        function qrm_spmat_nrm(spmat :: qrm_spmat{$elty}, ntype :: Char)
+        function qrm_spmat_nrm(spmat :: qrm_spmat{$elty}; ntype :: Char='f')
             nrm = Ref{$subty}(0)
             ptr_spmat = Ptr{qrm_spmat{$elty}}(pointer_from_objref(spmat))
             err = ccall(($fname, $lname), Cint, (Ptr{qrm_spmat{$elty}}, UInt8, Ref{$subty}), ptr_spmat, ntype, nrm)
@@ -330,7 +330,7 @@ for (fname, lname, elty, subty) in (("sqrm_vecnrm_c", libsqrm, Float32   , Float
                                     ("cqrm_vecnrm_c", libcqrm, ComplexF32, Float32),
                                     ("zqrm_vecnrm_c", libzqrm, ComplexF64, Float64))
     @eval begin
-        function qrm_vecnrm(x :: Vector{$elty}, ntype :: Char)
+        function qrm_vecnrm(x :: Vector{$elty}; ntype :: Char='2')
             n = length(x)
             nrhs = 1
             nrm = Ref{$subty}(0)
@@ -341,7 +341,7 @@ for (fname, lname, elty, subty) in (("sqrm_vecnrm_c", libsqrm, Float32   , Float
             return nrm[]
         end
 
-        function qrm_vecnrm(x :: Matrix{$elty}, ntype :: Char)
+        function qrm_vecnrm(x :: Matrix{$elty}; ntype :: Char='2')
             n, nrhs = size(x)
             nrm = zeros($subty, nrhs)
             err = ccall(($fname, $lname), Cint, (Ptr{$elty}, Cint, Cint, UInt8, Ptr{$subty}), pointer(x), n, nrhs, ntype, pointer(nrm))
@@ -351,7 +351,7 @@ for (fname, lname, elty, subty) in (("sqrm_vecnrm_c", libsqrm, Float32   , Float
             return nrm
         end
 
-        function qrm_vecnrm!(x :: Matrix{$elty}, ntype :: Char, nrm :: Vector{$subty})
+        function qrm_vecnrm!(x :: Matrix{$elty}, nrm :: Vector{$subty}; ntype :: Char='2')
             n, nrhs = size(x)
             err = ccall(($fname, $lname), Cint, (Ptr{$elty}, Cint, Cint, UInt8, Ptr{$subty}), pointer(x), n, nrhs, ntype, pointer(nrm))
             if err ≠ 0


### PR DESCRIPTION
@abuttari Do you prefer `ntype` as an argument or a keyword argument like `transp` ?
It concerns `qrm_spmat_nrm` and `qrm_vecnrm` functions.

PS : https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/#Passing-Pointers-for-Modifying-Inputs